### PR TITLE
use pxjahyper to support Japanese in pdf TOC

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -35,7 +35,8 @@
 \renewcommand{\baselinestretch}{1.15}
 
 \usepackage{appendix}
-\usepackage{hyperref}
+\usepackage[dvipdfmx]{hyperref}
+\usepackage{pxjahyper}
 \usepackage{makeidx}
 \makeindex
 


### PR DESCRIPTION
PDFの目次が文字化けしていたのが気になったので、以下を参考に pxjahyper を使用するよう変更しました。
http://u09.hatenablog.com/entry/2017/07/30/191444
