### PR TITLE
fixed a typo in fvalue.tex

### DIFF
--- a/figures/fvalue.tex
+++ b/figures/fvalue.tex
@@ -14,5 +14,5 @@
 
 
 \draw[->] (s0) -- (c) node[above,pos=0.5] {$g(u)$};
-\draw[->,dashed] (c) -- (g) node[above,pos=0.5] {$h(u)$};
+\draw[->,dashed] (c) -- (t) node[above,pos=0.5] {$h(u)$};
 


### PR DESCRIPTION
f値の説明の図の矢印が重なっていました。本文に合わせて修正しましたが、ご確認ください。